### PR TITLE
fix: use Pip from Miniconda dir

### DIFF
--- a/UVR5-UI-updater.bat
+++ b/UVR5-UI-updater.bat
@@ -6,6 +6,7 @@ set "INSTALL_DIR=%cd%"
 set "MINICONDA_DIR=%UserProfile%\Miniconda3"
 set "ENV_DIR=%INSTALL_DIR%\env"
 set "CONDA_EXE=%MINICONDA_DIR%\Scripts\conda.exe"
+set "PIP_EXE=%MINICONDA_DIR%\Scripts\pip.exe"
 
 where git > nul 2>&1
 if %errorlevel% neq 0 (
@@ -50,7 +51,7 @@ if errorlevel 1 (
 )
 
 echo Checking for updated dependencies...
-pip install -r "%INSTALL_DIR%\requirements.txt" || goto :error
+%PIP_EXE% install -r "%INSTALL_DIR%\requirements.txt" || goto :error
 
 call "%MINICONDA_DIR%\condabin\conda.bat" deactivate
 if errorlevel 1 (


### PR DESCRIPTION
When running updater batch file, when it runs `pip install -r` , it always seems to error out with the message:

> Fatal error in launcher: Unable to create process using '"C:\Users\zhari\Downloads\UVR5-UI\env\python.exe"

After digging this up, it seems to be because directly invoking `pip` finds pip in the env directory (which is part of the zip release archive). Most likely, that version of pip was built from source, so it has the location baked in,

This PR changes that to use pip.exe from the `%MINICONDA_DIR%\Scripts\` location.